### PR TITLE
Get room by

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -79,12 +79,13 @@ def create_app(config_name='default'):
         }), 404
 
     from api.resources.users import UsersResource, UserResource
-    from api.resources.rooms import RoomsResource
+    from api.resources.rooms import RoomsResource, RoomResource
     from api.resources.memories import MemoriesResource
 
     api.add_resource(RoomsResource, '/api/v1/users/<user_id>/rooms')
     api.add_resource(UserResource, '/api/v1/users/<user_id>')
     api.add_resource(UsersResource, '/api/v1/users')
     api.add_resource(MemoriesResource, '/api/v1/rooms/<room_id>/memories')
+    api.add_resource(RoomResource, '/api/v1/rooms/<room_id>')
 
     return app

--- a/api/resources/rooms.py
+++ b/api/resources/rooms.py
@@ -43,3 +43,14 @@ class RoomsResource(Resource):
             'success': True,
             'data': results
         }, 200
+
+class RoomResource(Resource):
+    def get(self, *args, **kwargs):
+        room_id = int(bleach.clean(kwargs['room_id'].strip()))
+        room = db.session.query(Room).filter_by(id=room_id).one()
+
+        results = _room_payload(room)
+        return {
+            'success': True,
+            'data': results
+        }, 200

--- a/tests/endpoints/rooms/test_get_one_room.py
+++ b/tests/endpoints/rooms/test_get_one_room.py
@@ -1,0 +1,25 @@
+import json
+import unittest
+
+from api import create_app, db
+from api.database.models import User, Room
+from tests import db_drop_everything, assert_payload_field_type_value, \
+    assert_payload_field_type
+
+class GetRoomTest(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        self.user_1 = User(name='zzz 1', email='e1')
+        self.user_1.insert()
+
+    def tearDown(self):
+        db.session.remove()
+        db_drop_everything(db)
+        self.app_context.pop()
+
+    def test_happypath_get_a_user(self):

--- a/tests/endpoints/rooms/test_get_one_room.py
+++ b/tests/endpoints/rooms/test_get_one_room.py
@@ -36,13 +36,13 @@ class GetRoomTest(unittest.TestCase):
       assert_payload_field_type_value(self, data, 'success', bool, True)
       
       results = data['data']
-
+     
       assert_payload_field_type_value(
-            self, results, 'name', str, self.room_2.name
+            self, results, 'name', str, room_2.name
         )
       assert_payload_field_type_value(
-          self, results, 'image', str, self.room_2.image
+          self, results, 'image', str, room_2.image
       )
       assert_payload_field_type_value(
-          self, results, 'user_id', str, self.user_1.id
+          self, results, 'user_id', int, user_1.id
       )

--- a/tests/endpoints/rooms/test_get_one_room.py
+++ b/tests/endpoints/rooms/test_get_one_room.py
@@ -14,12 +14,35 @@ class GetRoomTest(unittest.TestCase):
         db.create_all()
         self.client = self.app.test_client()
 
-        self.user_1 = User(name='zzz 1', email='e1')
-        self.user_1.insert()
-
     def tearDown(self):
         db.session.remove()
         db_drop_everything(db)
         self.app_context.pop()
 
-    def test_happypath_get_a_user(self):
+    def test_happypath_get_a_room(self):
+      user_1 = User(name='Test User', email='email 1')
+      user_1.insert()
+      room_1 = Room(name='Kitchen', image='exampleimage1.com', user_id=user_1.id)
+      room_1.insert()
+      room_2 = Room(name='Living Room', image='exampleimage2.com', user_id=user_1.id)
+      room_2.insert()
+
+      response = self.client.get(
+      f'/api/v1/rooms/{room_2.id}'
+      )
+      self.assertEqual(200, response.status_code)
+
+      data = json.loads(response.data.decode('utf-8'))
+      assert_payload_field_type_value(self, data, 'success', bool, True)
+      
+      results = data['data']
+
+      assert_payload_field_type_value(
+            self, results, 'name', str, self.room_2.name
+        )
+      assert_payload_field_type_value(
+          self, results, 'image', str, self.room_2.image
+      )
+      assert_payload_field_type_value(
+          self, results, 'user_id', str, self.user_1.id
+      )


### PR DESCRIPTION
Create the endpoint `rooms/:id`

## Description
Update rooms resource to allow for a single room by id endpoint.
Add testing for this endpoint.

## Related Issue
Closes Issue #18 

## Motivation and Context
Allow endpoint for front end to call for an individual room.

## How Has This Been Tested?
Testing implemented for happy paths, but not sad paths

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
